### PR TITLE
updated urllib3 package version (CVE)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ Click==7.0
 idna==2.7
 requests==2.20.0
 Shapely==1.6.4.post2
-urllib3==1.24
+urllib3==1.24.2


### PR DESCRIPTION
need to fix it to 1.24.2 for the moment, any higher (like 1.25 results in a conflict with requests 2.20 or higher that requires urllib3 < 1.25)